### PR TITLE
Tighter BioCompute Object Integration

### DIFF
--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -8,6 +8,8 @@ import type { AdminJobs as AdminJobs_ } from './v1/admin/jobs'
 export const AdminJobs = APIInterface<typeof AdminJobs_>("/api/v1/admin/jobs", "GET")
 import type { UserIntegrationsBioComputeAuth as UserIntegrationsBioComputeAuth_ } from './v1/user/integrations/biocompute'
 export const UserIntegrationsBioComputeAuth = APIInterface<typeof UserIntegrationsBioComputeAuth_>("/api/v1/user/integrations/biocompute/auth", "GET")
+import type { UserIntegrationsBioComputePublishedBCO as UserIntegrationsBioComputePublishedBCO_ } from './v1/user/integrations/biocompute'
+export const UserIntegrationsBioComputePublishedBCO = APIInterface<typeof UserIntegrationsBioComputePublishedBCO_>("/api/v1/user/integrations/biocompute/[fpl_id]/published", "GET")
 import type { UserIntegrationsCAVATICA as UserIntegrationsCAVATICA_ } from './v1/user/integrations/cavatica'
 export const UserIntegrationsCAVATICA = APIInterface<typeof UserIntegrationsCAVATICA_>("/api/v1/user/integrations/cavatica", "GET")
 import type { UserIntegrationsCAVATICAUpdate as UserIntegrationsCAVATICAUpdate_ } from './v1/user/integrations/cavatica'

--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -6,6 +6,8 @@
 import { APIInterface } from '@/spec/api'
 import type { AdminJobs as AdminJobs_ } from './v1/admin/jobs'
 export const AdminJobs = APIInterface<typeof AdminJobs_>("/api/v1/admin/jobs", "GET")
+import type { UserIntegrationsBioComputeAuth as UserIntegrationsBioComputeAuth_ } from './v1/user/integrations/biocompute'
+export const UserIntegrationsBioComputeAuth = APIInterface<typeof UserIntegrationsBioComputeAuth_>("/api/v1/user/integrations/biocompute/auth", "GET")
 import type { UserIntegrationsCAVATICA as UserIntegrationsCAVATICA_ } from './v1/user/integrations/cavatica'
 export const UserIntegrationsCAVATICA = APIInterface<typeof UserIntegrationsCAVATICA_>("/api/v1/user/integrations/cavatica", "GET")
 import type { UserIntegrationsCAVATICAUpdate as UserIntegrationsCAVATICAUpdate_ } from './v1/user/integrations/cavatica'

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -4,5 +4,6 @@
  * It is designed to be imported server-side.
  */
 export * from "./v1/admin/jobs"
+export * from "./v1/user/integrations/biocompute"
 export * from "./v1/user/integrations/cavatica"
 export * from "./v1/user/playbooks"

--- a/app/api/v1/user/integrations/biocompute/index.ts
+++ b/app/api/v1/user/integrations/biocompute/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { API } from '@/spec/api'
 import db from '@/app/db'
 import { getServerSessionWithId } from '@/app/extensions/next-auth/helpers'
+import { ResponseCodedError, UnauthorizedError } from '@/spec/error'
 
 export const UserIntegrationsBioComputeAuth = API.get('/api/v1/user/integrations/biocompute/auth')
   .query(z.object({}))
@@ -27,5 +28,33 @@ export const UserIntegrationsBioComputeAuth = API.get('/api/v1/user/integrations
         orcid: userOrcidAccount !== undefined,
       }
     }
+  })
+  .build()
+
+export const UserIntegrationsBioComputePublishedBCO = API.get('/api/v1/user/integrations/biocompute/[fpl_id]/published')
+  .query(z.object({
+    fpl_id: z.string(),
+  }))
+  .call(async (inputs, req, res) => {
+    const session = await getServerSessionWithId(req, res)
+    if (!session?.user?.id) throw new UnauthorizedError()
+    const user = await db.objects.user.findUnique({ where: { id: session.user.id } })
+    if (!user) throw new UnauthorizedError()
+    // @ts-ignore
+    const userOrcidAccount = user ? await db.objects.account.findUnique({ where: { userId: user.id, provider: 'orcid' } }) : undefined
+    if (!userOrcidAccount) throw new UnauthorizedError('ORCID Required')
+    // TODO: this gives me unauthorized even when ORCID is properly configured
+    const bcoReq = await fetch(`https://biocomputeobject.org/api/objects/?contents=${encodeURIComponent(`${process.env.PUBLIC_URL}/report/${inputs.query.fpl_id}`)}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${userOrcidAccount.id_token}`,
+      },
+    })
+    if (!bcoReq.ok) throw new ResponseCodedError(bcoReq.status, await bcoReq.text())
+    const results = await bcoReq.json()
+    // TODO: verify that the results are as we expect
+    // console.log(results)
+    return Array.isArray(results) && results.length > 0 ? results[0].object_id : null
   })
   .build()

--- a/app/api/v1/user/integrations/biocompute/index.ts
+++ b/app/api/v1/user/integrations/biocompute/index.ts
@@ -30,38 +30,61 @@ export const UserIntegrationsBioComputeAuth = API.get('/api/v1/user/integrations
   })
   .build()
 
+const BCOListResponseC = z.array(z.array(z.object({
+  contents: z.object({
+    object_id: z.string(),
+    provenance_domain: z.object({
+      derived_from: z.string(),
+    }),
+  }),
+  state: z.enum(['DRAFT', 'PUBLISHED']),
+})))
+
 export const UserIntegrationsBioComputePublishedBCO = API.get('/api/v1/user/integrations/biocompute/[fpl_id]/published')
   .query(z.object({
     fpl_id: z.string(),
   }))
   .call(async (inputs, req, res) => {
-    const session = await getServerSessionWithId(req, res)
-    if (!session?.user?.id) throw new UnauthorizedError()
-    const user = await db.objects.user.findUnique({ where: { id: session.user.id } })
-    if (!user) throw new UnauthorizedError()
-    // @ts-ignore
-    const userOrcidAccount = user ? await db.objects.account.findUnique({ where: { userId: user.id, provider: 'orcid' } }) : undefined
-    if (!userOrcidAccount) throw new UnauthorizedError('ORCID Required')
-    const persistent_url = `${process.env.PUBLIC_URL}/report/${inputs.query.fpl_id}`
-    const bcoReq = await fetch(`https://biocomputeobject.org/api/objects/?contents=${encodeURIComponent(persistent_url)}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${userOrcidAccount.id_token}`,
-      },
-    })
-    if (!bcoReq.ok) throw new ResponseCodedError(bcoReq.status, await bcoReq.text())
-    const results = z.array(z.array(z.object({
-      contents: z.object({
-        object_id: z.string(),
-        provenance_domain: z.object({
-          derived_from: z.string(),
-        }),
-      }),
-      state: z.string(),
-    }))).parse(await bcoReq.json())
-      .flatMap(r => r)
-      .filter(item => item.contents.provenance_domain.derived_from === persistent_url)
-    return results.length > 0 ? results[0].contents.object_id : null
+    try {
+      const session = await getServerSessionWithId(req, res)
+      if (!session?.user?.id) throw new UnauthorizedError()
+      const user = await db.objects.user.findUnique({ where: { id: session.user.id } })
+      if (!user) throw new UnauthorizedError()
+      // @ts-ignore
+      const userOrcidAccount = user ? await db.objects.account.findUnique({ where: { userId: user.id, provider: 'orcid' } }) : undefined
+      if (!userOrcidAccount) throw new UnauthorizedError('ORCID Required')
+      // logged in, look for drafts
+      const persistent_url = `${process.env.PUBLIC_URL}/report/${inputs.query.fpl_id}`
+      const bcoReq = await fetch(`https://biocomputeobject.org/api/objects/?contents=${encodeURIComponent(persistent_url)}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${userOrcidAccount.id_token}`,
+        },
+      })
+      if (!bcoReq.ok) throw new ResponseCodedError(bcoReq.status, await bcoReq.text())
+      const results = BCOListResponseC.parse(await bcoReq.json())
+        .flatMap(r => r)
+        .filter(item => item.contents.provenance_domain.derived_from === persistent_url)
+      const published = results.filter(result => result.state === 'PUBLISHED')
+      const drafts = results.filter(result => result.state === 'DRAFT')
+      return published.length > 0 ? published[0]
+        : drafts.length > 0 ? drafts[0]
+        : null
+    } catch (e) {
+      // not logged in, find published BCOs
+      const persistent_url = `${process.env.PUBLIC_URL}/report/${inputs.query.fpl_id}`
+      const bcoReq = await fetch(`https://biocomputeobject.org/api/objects/?contents=${encodeURIComponent(persistent_url)}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      if (!bcoReq.ok) throw new ResponseCodedError(bcoReq.status, await bcoReq.text())
+      const results = BCOListResponseC.parse(await bcoReq.json())
+        .flatMap(r => r)
+        .filter(item => item.contents.provenance_domain.derived_from === persistent_url)
+      return results.length > 0 ? results[0] : null
+    }
   })
   .build()

--- a/app/api/v1/user/integrations/biocompute/index.ts
+++ b/app/api/v1/user/integrations/biocompute/index.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import { API } from '@/spec/api'
+import db from '@/app/db'
+import { getServerSessionWithId } from '@/app/extensions/next-auth/helpers'
+
+export const UserIntegrationsBioComputeAuth = API.get('/api/v1/user/integrations/biocompute/auth')
+  .query(z.object({}))
+  .call(async (inputs, req, res) => {
+    const session = await getServerSessionWithId(req, res)
+    const user = (session && session.user) ? (await db.objects.user.findUnique({ where: { id: session.user.id } })) : undefined
+    // @ts-ignore
+    const userOrcidAccount = user ? await db.objects.account.findUnique({ where: { userId: user.id, provider: 'orcid' } }) : undefined
+    if (!userOrcidAccount) {
+      return { orcid: false }
+    } else {
+      // TODO: probably a better endpoint for this
+      const bcoReq = await fetch('https://biocomputeobject.org/api/objects/drafts/create/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${userOrcidAccount.id_token}`,
+        },
+        body: JSON.stringify({}),
+      })
+      return {
+        biocompute: bcoReq.status !== 403,
+        orcid: userOrcidAccount !== undefined,
+      }
+    }
+  })
+  .build()

--- a/app/api/v1/user/integrations/biocompute/index.ts
+++ b/app/api/v1/user/integrations/biocompute/index.ts
@@ -17,13 +17,13 @@ export const UserIntegrationsBioComputeAuth = API.get('/api/v1/user/integrations
       const bcoReq = await fetch('https://biocomputeobject.org/users/orcid/user_info/', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${userOrcidAccount.id_token}`,
+          'Accept': 'application/json',
+          'Authorization': `Token ${userOrcidAccount.id_token}`,
+          'Referer': 'https://playbook-workflow-builder.cloud',
         },
-        body: JSON.stringify({}),
       })
       return {
-        biocompute: bcoReq.status !== 403,
+        biocompute: bcoReq.status === 200,
         orcid: userOrcidAccount !== undefined,
       }
     }

--- a/app/fragments/account/biocompute.tsx
+++ b/app/fragments/account/biocompute.tsx
@@ -1,15 +1,38 @@
+import { UserIntegrationsBioComputeAuth } from "@/app/api/client"
+import { useAPIQuery } from "@/core/api/client"
+import classNames from "classnames"
+import { signIn } from "next-auth/react"
+import { useRouter } from "next/router"
+import React from "react"
+
 export default function BioCompute() {
+  const router = useRouter()
+  const { data: biocomputeAuth } = useAPIQuery(UserIntegrationsBioComputeAuth, {})
+  React.useEffect(() => {
+    if (biocomputeAuth?.orcid && biocomputeAuth.biocompute) {
+      if (router.query.callback) {
+        router.push(router.query.callback as string)
+      }
+    }
+  }, [biocomputeAuth, router.query.callback])
   return (
-    <>
+    <div className="prose">
       <h3 className="bp5-heading">BioCompute Integration</h3>
-      <div className="hero">
-        <div className="hero-content text-center">
-          <div className="max-w-md">
-            <h1 className="text-5xl font-bold prose">Coming Soon</h1>
-            <p className="py-6 prose">This feature is currently in development. This is currently a non-functioning mockup.</p>
+      <p>
+        BioCompute is a standardized way of representing a computational workflow.
+        The <a href="https://biocomputeobject.org/">BioCompute portal</a> lets users create, edit, and publish BioCompute Objects (BCOs).
+        To publish playbook partnership workflows on the BioCompute portal, you must have an account with the BioCompute portal.
+        Both your playbook workflow builder account AND your biocompute account should be associated with a common <a href="https://orcid.org/">ORCID</a>.
+      </p>
+      {biocomputeAuth ?
+        biocomputeAuth.orcid && biocomputeAuth.biocompute ? (
+          <div className="alert alert-success my-2">BioCompute Integration is active</div>
+        ) : (
+          <div className="flex flex-row gap-2 justify-around">
+            <a onClick={() => {signIn('orcid')}} className={classNames('btn', { 'btn-disabled': biocomputeAuth.orcid })}>Link Playbook Workflow Builder Account with ORCID</a>
+            <a href="https://biocomputeobject.org/profile" target="_blank" className={classNames('btn', { 'btn-disabled': biocomputeAuth.biocompute })}>Create BCO Account/Link ORCID</a>
           </div>
-        </div>
-      </div>
-    </>
+        ) : null}
+    </div>
   )
 }

--- a/app/fragments/account/layout.tsx
+++ b/app/fragments/account/layout.tsx
@@ -12,7 +12,7 @@ const AccountSettings = dynamic(() => import('@/app/fragments/account/settings')
 const AccountUploads = dynamic(() => import('@/app/fragments/account/uploads'))
 const AccountPlaybooks = dynamic(() => import('@/app/fragments/account/playbooks'))
 const AccountSuggestions = dynamic(() => import('@/app/fragments/account/suggestions'))
-// const AccountBioCompute = dynamic(() => import('@/app/fragments/account/biocompute'))
+const AccountBioCompute = dynamic(() => import('@/app/fragments/account/biocompute'))
 const AccountCAVATICA = dynamic(() => import('@/app/fragments/account/cavatica'))
 
 export default function Layout({ session }: { session: SessionWithId }) {
@@ -43,7 +43,7 @@ export default function Layout({ session }: { session: SessionWithId }) {
       <Bp5Tab id="suggestions" title={<><Bp5Icon icon="lightbulb" /> Suggestions</>} panelClassName="flex-grow flex flex-col overflow-hidden" panel={<AccountSuggestions />} />
       <hr className="h-px my-1 border-0 bg-secondary w-full" />
       <span className='font-bold'>Integrations</span>
-      {/* <Bp5Tab id="biocompute" title={<><Bp5Icon icon="application" /> BioCompute</>} panelClassName="flex-grow flex flex-col overflow-hidden" panel={<AccountBioCompute />} /> */}
+      <Bp5Tab id="biocompute" title={<><Bp5Icon icon="application" /> BioCompute</>} panelClassName="flex-grow flex flex-col overflow-hidden" panel={<AccountBioCompute />} />
       <Bp5Tab id="cavatica" title={<><Bp5Icon icon="application" /> CAVATICA</>} panelClassName="flex-grow flex flex-col overflow-hidden" panel={<AccountCAVATICA />} />
       <hr className="h-px my-1 border-0 bg-secondary w-full" />
       <span className='font-bold'>Session</span>

--- a/app/fragments/report/bco-button.tsx
+++ b/app/fragments/report/bco-button.tsx
@@ -3,6 +3,9 @@ import dynamic from 'next/dynamic'
 import useSWRMutation from 'swr/mutation'
 import { biocompute_icon } from '@/icons'
 import { fetcherPOST } from '@/utils/next-rest-fetcher'
+import { ResponseCodedError } from '@/spec/error'
+import { signIn, signOut } from 'next-auth/react'
+import { useRouter } from 'next/router'
 
 const Bp5Popover = dynamic(() => import('@blueprintjs/core').then(({ Popover }) => Popover))
 const Bp5Menu = dynamic(() => import('@blueprintjs/core').then(({ Menu }) => Menu))
@@ -12,12 +15,20 @@ const Bp5Alert = dynamic(() => import('@blueprintjs/core').then(({ Alert }) => A
 const Icon = dynamic(() => import('@/app/components/icon'))
 
 export default function BCOButton({ session_id, id, metadata, disabled }: { session_id?: string, id?: string, metadata: { title: string, description: string | undefined }, disabled: boolean }) {
+  const router = useRouter()
   const { trigger, isMutating, error } = useSWRMutation(id ? `${session_id ? `/api/socket/${session_id}` : ''}/api/bco/${id}/draft` : null, fetcherPOST<undefined, { object_id: string }>)
-  const [isError, setIsError] = React.useState(false)
+  const [showError, setShowError] = React.useState(false)
   React.useEffect(() => {
     if (error) {
-      setIsError(() => true)
       console.error(error)
+      setShowError(() => true)
+      if ((error as ResponseCodedError).message === 'ORCID Expired') {
+        signOut().then(() => signIn('orcid'))
+      } else if ((error as ResponseCodedError).message === 'ORCID Required') {
+        router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
+      } else if((error as ResponseCodedError).message === 'BCO Unauthorization') {
+        router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
+      }
     }
   }, [error])
   if (!id) return null
@@ -58,14 +69,14 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
         confirmButtonText="Okay"
         icon="error"
         intent="danger"
-        isOpen={isError}
+        isOpen={showError}
         canEscapeKeyCancel
         canOutsideClickCancel
-        onCancel={() => {setIsError(false)}}
-        onConfirm={() => {setIsError(false)}}
-      >
-        An error ocurred while attempting to register the BCO.
-        Please try again later.
+        onCancel={() => {setShowError(false)}}
+        onConfirm={() => {setShowError(false)}}
+      >{error ? (error as ResponseCodedError).message === 'ORCID Required' ? <>This feature requires your account to be linked with ORCID</>
+              : <>An error ocurred while attempting to register the BCO: {(error as ResponseCodedError).message}</>
+              : null}
       </Bp5Alert>
     </>
   )

--- a/app/fragments/report/bco-button.tsx
+++ b/app/fragments/report/bco-button.tsx
@@ -50,7 +50,7 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
               />
             </a>
             {publishedBCO ? /* TODO: get the right link */
-              <a href={`https://biocomputeobject.org/builder?https://biocomputeobject.org/${publishedBCO}/DRAFT`}>
+              <a href={`https://biocomputeobject.org/builder?${publishedBCO}`}>
                 <Bp5MenuItem
                   icon="link"
                   text="View in BioCompute Portal"
@@ -61,7 +61,7 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
                 text="Draft in BioCompute Portal"
                 onClick={async (evt) => {
                   trigger().then((res) => {
-                    if (res) window.open(`https://biocomputeobject.org/builder?${res.object_id}`, '_blank')
+                    if (res) window.open(res.object_id, '_blank')
                   })
                 }}
               />}

--- a/app/fragments/report/bco-button.tsx
+++ b/app/fragments/report/bco-button.tsx
@@ -25,7 +25,15 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
   else if (isMutating) return <Bp5Spinner className="inline-block" size={20} />
   return (
     <>
-      <Bp5Popover
+    {publishedBCO ?
+      <a className="bp5-button bp5-minimal" href={`https://biocomputeobject.org/${publishedBCO.state === 'PUBLISHED' ? 'viewer' : 'builder'}?${publishedBCO.contents.object_id}`} target="_blank">
+        <Icon
+          icon={biocompute_icon}
+          className={publishedBCO.state === 'PUBLISHED' ? 'fill-green-500' : 'fill-yellow-400'}
+          title="View in BioCompute Portal"
+        />
+      </a>
+      : <Bp5Popover
         className={disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
         disabled={disabled}
         content={
@@ -36,35 +44,28 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
                 text="Download BCO"
               />
             </a>
-            {publishedBCO ? /* TODO: get the right link */
-              <a href={`https://biocomputeobject.org/builder?${publishedBCO}`}>
-                <Bp5MenuItem
-                  icon="link"
-                  text="View in BioCompute Portal"
-                />
-              </a>
-              : <Bp5MenuItem
-                icon="send-to"
-                text="Draft in BioCompute Portal"
-                onClick={async (evt) => {
-                  trigger()
-                    .then((res) => {
-                      if (res) window.open(res.object_id, '_blank')
-                    })
-                  .catch((error) => {
-                    console.error(error)
-                    setShowError(() => true)
-                    console.log(`err ${(error as ResponseCodedError).message}`)
-                    if ((error as ResponseCodedError).message === 'ORCID Expired') {
-                      signOut().then(() => signIn('orcid'))
-                    } else if ((error as ResponseCodedError).message === 'ORCID Required') {
-                      router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
-                    } else if((error as ResponseCodedError).message === 'BCO Unauthorization') {
-                      router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
-                    }
+            <Bp5MenuItem
+              icon="send-to"
+              text="Draft in BioCompute Portal"
+              onClick={async (evt) => {
+                trigger()
+                  .then((res) => {
+                    if (res) window.open(res.object_id, '_blank')
                   })
-                }}
-              />}
+                .catch((error) => {
+                  console.error(error)
+                  setShowError(() => true)
+                  console.log(`err ${(error as ResponseCodedError).message}`)
+                  if ((error as ResponseCodedError).message === 'ORCID Expired') {
+                    signOut().then(() => signIn('orcid'))
+                  } else if ((error as ResponseCodedError).message === 'ORCID Required') {
+                    router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
+                  } else if((error as ResponseCodedError).message === 'BCO Unauthorization') {
+                    router.push(`/account/biocompute?callback=${decodeURIComponent(window.location.href)}`)
+                  }
+                })
+              }}
+            />
           </Bp5Menu>
         }
         placement="bottom"
@@ -74,7 +75,7 @@ export default function BCOButton({ session_id, id, metadata, disabled }: { sess
           className={publishedBCO ? 'fill-green-500' : disabled ? 'fill-gray-400' : 'fill-black dark:fill-white'}
           title={disabled ? 'Save to Create BCO' : 'Create BCO'}
         />
-      </Bp5Popover>
+      </Bp5Popover>}
       <Bp5Alert
         confirmButtonText="Okay"
         icon="error"

--- a/app/pages/api/[..._path].ts
+++ b/app/pages/api/[..._path].ts
@@ -65,6 +65,6 @@ export default handler(async (req, res) => {
     console.warn(e)
     throw new NotFoundError()
   }
-  if (!(req.method in component_handlers)) throw new UnsupportedMethodError()
-  await component_handlers[req.method](req, res, { throwOnError: false })
+  if (!(req.method in component_handlers)) throw new UnsupportedMethodError(req.method)
+  await component_handlers[req.method](req, res)
 })

--- a/app/pages/api/bco/[fpl_id]/draft.ts
+++ b/app/pages/api/bco/[fpl_id]/draft.ts
@@ -54,7 +54,7 @@ export default handler(async (req, res) => {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${userOrcidAccount.id_token}`,
     },
-    body: JSON.stringify({contents: BCO, origin: "https://playbook-workflow-builder.cloud "}),
+    body: JSON.stringify({contents: BCO, origin: "https://playbook-workflow-builder.cloud"}),
   })
   if (bcoReq.status === 403) {
     throw new UnauthorizedError('BCO Unauthorization')

--- a/app/pages/api/bco/[fpl_id]/draft.ts
+++ b/app/pages/api/bco/[fpl_id]/draft.ts
@@ -48,7 +48,7 @@ export default handler(async (req, res) => {
       }),
     },
   })
-  const bcoReq = await fetch('https://biocomputeobject.orgusers/bcodb/draft_bco/add', {
+  const bcoReq = await fetch('https://biocomputeobject.org/users/bcodb/draft_bco/add', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/app/pages/api/bco/[fpl_id]/draft.ts
+++ b/app/pages/api/bco/[fpl_id]/draft.ts
@@ -48,28 +48,19 @@ export default handler(async (req, res) => {
       }),
     },
   })
-  const bcoReq = await fetch('https://biocomputeobject.org/users/bcodb/draft_bco/add', {
+  const bcoReq = await fetch('https://biocomputeobject.orgusers/bcodb/draft_bco/add', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${userOrcidAccount.id_token}`,
     },
-    body: JSON.stringify({
-      POST_api_objects_draft_create: [
-        {
-          contents: BCO,
-          prefix: "BCO",
-          schema: "IEEE",
-          owner_group: "bco_drafter"
-        }
-      ]
-    }),
+    body: JSON.stringify({contents: BCO, origin: "https://playbook-workflow-builder.cloud "}),
   })
   if (bcoReq.status === 403) {
     throw new UnauthorizedError('BCO Unauthorization')
   } else if (bcoReq.status !== 200) {
     throw new ResponseCodedError(bcoReq.status, await bcoReq.text())
   }
-  const [bcoRes] = z.array(z.object({ object_id: z.string() })).parse(await bcoReq.json())
+  const bcoRes = z.object({ object_id: z.string() }).parse(await bcoReq.json())
   res.status(200).json(bcoRes)
 })

--- a/app/pages/api/bco/[fpl_id]/draft.ts
+++ b/app/pages/api/bco/[fpl_id]/draft.ts
@@ -48,7 +48,7 @@ export default handler(async (req, res) => {
       }),
     },
   })
-  const bcoReq = await fetch('https://biocomputeobject.org/api/objects/drafts/create/', {
+  const bcoReq = await fetch('https://biocomputeobject.org/users/bcodb/draft_bco/add', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/app/pages/api/bco/[fpl_id]/draft.ts
+++ b/app/pages/api/bco/[fpl_id]/draft.ts
@@ -19,7 +19,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'HEAD' && req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'HEAD' && req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const { fpl_id, metadata } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()
@@ -29,8 +29,8 @@ export default handler(async (req, res) => {
   if (!user.name) throw new Error('Name required')
   // @ts-ignore
   const userOrcidAccount = await db.objects.account.findUnique({ where: { userId: user.id, provider: 'orcid' } })
-  if (!userOrcidAccount) throw new Error('ORCID Required')
-  if (Date.now()/1000 > userOrcidAccount.expires_at) throw new Error('ORCID Expired, Please Log in Again')
+  if (!userOrcidAccount) throw new UnauthorizedError('ORCID Required')
+  if (Date.now()/1000 > userOrcidAccount.expires_at) throw new UnauthorizedError('ORCID Expired')
   if (req.method === 'HEAD') {
     res.status(200).end()
     return

--- a/app/pages/api/bco/[fpl_id]/index.ts
+++ b/app/pages/api/bco/[fpl_id]/index.ts
@@ -19,7 +19,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'HEAD' && req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'HEAD' && req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { fpl_id, metadata } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/chatgpt.tsx
+++ b/app/pages/api/chatgpt.tsx
@@ -14,7 +14,7 @@ export default handler(async (req, res) => {
     res.status(200).end()
     return
   }
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const body = BodyType.parse(req.body)
   const gptReq = await fetch(`https://api.openai.com/v1/chat/completions`, {
     method: 'POST',

--- a/app/pages/api/config.tsx
+++ b/app/pages/api/config.tsx
@@ -3,7 +3,7 @@ import handler from '@/utils/next-rest'
 import * as dict from '@/utils/dict'
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   res.status(200).json(
     dict.filter(
       process.env as Record<string, string>,

--- a/app/pages/api/db/fpl/[fpl_id]/export.ts
+++ b/app/pages/api/db/fpl/[fpl_id]/export.ts
@@ -9,7 +9,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { fpl_id } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/[fpl_id]/extend.ts
+++ b/app/pages/api/db/fpl/[fpl_id]/extend.ts
@@ -12,7 +12,7 @@ const BodyType = IdOrProcessC
 
 export default handler(async (req, res) => {
   if (!fpprg) throw new ResponseCodedError(503, 'Not ready')
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const { fpl_id } = QueryType.parse(req.query)
   const process = await fpprg.resolveProcess(BodyType.parse(req.body))
   if (fpl_id === 'start') {

--- a/app/pages/api/db/fpl/[fpl_id]/index.ts
+++ b/app/pages/api/db/fpl/[fpl_id]/index.ts
@@ -8,7 +8,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { fpl_id } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/[fpl_id]/output/export.ts
+++ b/app/pages/api/db/fpl/[fpl_id]/output/export.ts
@@ -9,7 +9,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { fpl_id } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/[fpl_id]/output/index.ts
+++ b/app/pages/api/db/fpl/[fpl_id]/output/index.ts
@@ -8,7 +8,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { fpl_id } = QueryType.parse(req.query)
   const fpl = await fpprg.getFPL(fpl_id)
   if (fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/[fpl_id]/rebase/[process_id].ts
+++ b/app/pages/api/db/fpl/[fpl_id]/rebase/[process_id].ts
@@ -12,7 +12,7 @@ const QueryType = z.object({
 const BodyType = IdOrProcessC
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const { fpl_id, process_id } = QueryType.parse(req.query)
   const old_process = await fpprg.getProcess(process_id)
   if (old_process === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/[fpl_id]/rebaseMetadata/[rebase_id].ts
+++ b/app/pages/api/db/fpl/[fpl_id]/rebaseMetadata/[rebase_id].ts
@@ -12,7 +12,7 @@ const QueryType = z.object({
 const BodyType = IdOrPlaybookMetadataC
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const { fpl_id, rebase_id } = QueryType.parse(req.query)
   const rebase_fpl = await fpprg.getFPL(rebase_id)
   if (rebase_fpl === undefined) throw new NotFoundError()

--- a/app/pages/api/db/fpl/index.ts
+++ b/app/pages/api/db/fpl/index.ts
@@ -12,7 +12,7 @@ const BodyType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   // load the submitted processArray specification
   const { data = {}, workflow, metadata } = BodyType.parse(req.body)
   // resolve the process array by walking through the specification, collecting instantiated processes

--- a/app/pages/api/db/process/[process_id]/index.ts
+++ b/app/pages/api/db/process/[process_id]/index.ts
@@ -8,7 +8,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { process_id } = QueryType.parse(req.query)
   const process = await fpprg.getProcess(process_id)
   if (process === undefined) throw new NotFoundError()

--- a/app/pages/api/db/process/[process_id]/inputs.ts
+++ b/app/pages/api/db/process/[process_id]/inputs.ts
@@ -2,7 +2,7 @@ import krg from '@/app/krg'
 import fpprg from '@/app/fpprg'
 import { z } from 'zod'
 import handler from '@/utils/next-rest'
-import { NotFoundError } from '@/spec/error'
+import { NotFoundError, UnsupportedMethodError } from '@/spec/error'
 import { decode_complete_process_inputs } from '@/core/engine'
 
 const QueryType = z.object({
@@ -10,7 +10,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new Error('Unsupported method')
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { process_id } = QueryType.parse(req.query)
   const process = await fpprg.getProcess(process_id)
   if (process === undefined) throw new NotFoundError()

--- a/app/pages/api/db/process/[process_id]/output/delete.ts
+++ b/app/pages/api/db/process/[process_id]/output/delete.ts
@@ -1,14 +1,14 @@
 import fpprg from '@/app/fpprg'
 import { z } from 'zod'
 import handler from '@/utils/next-rest'
-import { NotFoundError } from '@/spec/error'
+import { NotFoundError, UnsupportedMethodError } from '@/spec/error'
 
 const QueryType = z.object({
   process_id: z.string(),
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new Error('Unsupported method')
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const { process_id } = QueryType.parse(req.query)
   const resolved = await fpprg.getResolved(process_id)
   if (resolved === undefined) throw new NotFoundError()

--- a/app/pages/api/db/process/[process_id]/output/index.ts
+++ b/app/pages/api/db/process/[process_id]/output/index.ts
@@ -1,14 +1,14 @@
 import fpprg from '@/app/fpprg'
 import { z } from 'zod'
 import handler from '@/utils/next-rest'
-import { NotFoundError } from '@/spec/error'
+import { NotFoundError, UnsupportedMethodError } from '@/spec/error'
 
 const QueryType = z.object({
   process_id: z.string(),
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new Error('Unsupported method')
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { process_id } = QueryType.parse(req.query)
   const process = await fpprg.getProcess(process_id)
   if (process === undefined) throw new NotFoundError()

--- a/app/pages/api/db/user/[id]/profile.ts
+++ b/app/pages/api/db/user/[id]/profile.ts
@@ -8,7 +8,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   const { id } = QueryType.parse(req.query)
   const user = await db.objects.user.findUnique({ where: { id } })
   if (user === null) throw new NotFoundError()

--- a/app/pages/api/db/user/delete.ts
+++ b/app/pages/api/db/user/delete.ts
@@ -4,7 +4,7 @@ import handler from '@/utils/next-rest'
 import { NotFoundError, UnauthorizedError, UnsupportedMethodError } from '@/spec/error'
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const session = await getServerSessionWithId(req, res)
   if (!session || !session.user) throw new UnauthorizedError()
   const deletedUser = await db.objects.user.delete({ where: { id: session.user.id } })

--- a/app/pages/api/db/user/profile.ts
+++ b/app/pages/api/db/user/profile.ts
@@ -28,6 +28,6 @@ export default handler(async (req, res) => {
       data: BodyType.parse(req.body),
     }))
   } else {
-    throw new UnsupportedMethodError()
+    throw new UnsupportedMethodError(req.method)
   }
 })

--- a/app/pages/api/db/user/suggestions/[id]/delete.ts
+++ b/app/pages/api/db/user/suggestions/[id]/delete.ts
@@ -9,7 +9,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const session = await getServerSessionWithId(req, res)
   if (!session || !session.user) throw new UnauthorizedError()
   const { id } = QueryType.parse(req.query)

--- a/app/pages/api/db/user/suggestions/index.ts
+++ b/app/pages/api/db/user/suggestions/index.ts
@@ -10,6 +10,6 @@ export default handler(async (req, res) => {
     const suggestions = await db.objects.suggestion.findMany({ where: { user: session.user.id } })
     return res.status(200).json(suggestions)
   } else {
-    throw new UnsupportedMethodError()
+    throw new UnsupportedMethodError(req.method)
   }
 })

--- a/app/pages/api/db/user/uploads/[id]/delete.ts
+++ b/app/pages/api/db/user/uploads/[id]/delete.ts
@@ -9,7 +9,7 @@ const QueryType = z.object({
 })
 
 export default handler(async (req, res) => {
-  if (req.method !== 'POST') throw new UnsupportedMethodError()
+  if (req.method !== 'POST') throw new UnsupportedMethodError(req.method)
   const session = await getServerSessionWithId(req, res)
   if (!session || !session.user) throw new UnauthorizedError()
   const { id } = QueryType.parse(req.query)

--- a/app/pages/api/db/user/uploads/index.ts
+++ b/app/pages/api/db/user/uploads/index.ts
@@ -13,6 +13,6 @@ export default handler(async (req, res) => {
     })
     return res.status(200).json(uploads)
   } else {
-    throw new UnsupportedMethodError()
+    throw new UnsupportedMethodError(req.method)
   }
 })

--- a/app/pages/api/ga4gh/drs/v1/service-info.ts
+++ b/app/pages/api/ga4gh/drs/v1/service-info.ts
@@ -3,7 +3,7 @@ import { UnsupportedMethodError } from '@/spec/error'
 import packageJson from '@/package.json'
 
 export default handler(async (req, res) => {
-  if (req.method !== 'GET') throw new UnsupportedMethodError()
+  if (req.method !== 'GET') throw new UnsupportedMethodError(req.method)
   res.json(JSON.stringify({
     "id": "cloud.playbook-workflow-builder",
     "name": "Playbook Workflow Builder",

--- a/app/pages/api/suggest.tsx
+++ b/app/pages/api/suggest.tsx
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import dynamic from 'next/dynamic'
 import { z } from 'zod'
 import { MetaNode } from '@/spec/metanode'
+import { UnsupportedMethodError } from '@/spec/error'
 
 const UserIdentity = dynamic(() => import('@/app/fragments/graph/useridentity'))
 
@@ -62,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       await db.objects.suggestion.create({ data: suggestion })
       res.status(200).end()
     } else {
-      throw new Error('Unsupported method')
+      throw new UnsupportedMethodError(req.method)
     }
   } catch (e) {
     console.error(e)

--- a/core/api/router.ts
+++ b/core/api/router.ts
@@ -65,7 +65,7 @@ export default class APIRouter {
     const url = new URL(req.url, `http://${req.headers.host}`)
     const match = this.find(url.pathname)
     if (typeof match === 'undefined') throw new NotFoundError()
-    if (!req.method || !(req.method in match.routes)) throw new UnsupportedMethodError()
+    if (!req.method || !(req.method in match.routes)) throw new UnsupportedMethodError(req.method)
     const route = match.routes[req.method]
     const query = route.parameters.parse(
       dict.init(dict.items({ ...match.pathParams, ...Object.fromEntries(url.searchParams.entries()) }).map(({ key, value }) => ({ key, value: tryJsonParse(value) })))

--- a/core/fpl2bco.ts
+++ b/core/fpl2bco.ts
@@ -86,8 +86,9 @@ export default async function FPL2BCO(props: { krg: KRG, fpl: FPL, metadata?: Me
         'Playbook Workflow Builder',
         ...array.unique(
           dict.values(processLookup)
-            .flatMap(({ metanode }) => metanode.meta.tags ? dict.items(metanode.meta.tags) : [])
-            .flatMap(({ key, value }) => dict.keys(value).map(tag => `${tag} (${key})`))
+            .flatMap(({ metanode }) =>
+              metanode.meta.tags ? dict.items(metanode.meta.tags).flatMap(({ key: _, value }) => dict.keys(value)).join(' ') : []
+            )
         )
       ],
       platform: ['Debian GNU/Linux 11'],

--- a/core/fpl2bco.ts
+++ b/core/fpl2bco.ts
@@ -82,12 +82,14 @@ export default async function FPL2BCO(props: { krg: KRG, fpl: FPL, metadata?: Me
       modified: toBCOTimeString(), // TODO: datetime
     },
     description_domain: {
-      keywords: array.unique(
-        dict.values(processLookup)
-          .flatMap(({ metanode }) =>
-            metanode.meta.tags ? dict.keys(metanode.meta.tags) : []
-          )
-      ),
+      keywords: [
+        'Playbook Workflow Builder',
+        ...array.unique(
+          dict.values(processLookup)
+            .flatMap(({ metanode }) => metanode.meta.tags ? dict.items(metanode.meta.tags) : [])
+            .flatMap(({ key, value }) => dict.keys(value).map(tag => `${tag} (${key})`))
+        )
+      ],
       platform: ['Debian GNU/Linux 11'],
       pipeline_steps: dict.values(processLookup).map(({ index, node, metanode }) => ({
         name: metanode.meta.label,

--- a/core/fpl2bco.ts
+++ b/core/fpl2bco.ts
@@ -42,11 +42,11 @@ export default async function FPL2BCO(props: { krg: KRG, fpl: FPL, metadata?: Me
     await Promise.all(fullFPL.map(async (step, index) => {
       const metanode = props.krg.getProcessNode(step.process.type)
       let story: string | undefined
-      if (props.metadata?.description) {
-        story = undefined
-      } else {
-        const inputs = await decode_complete_process_inputs(props.krg, step.process)
-        const output = await decode_complete_process_output(props.krg, step.process)
+      if (!props.metadata?.description) {
+        let inputs: Record<string, unknown> | undefined
+        try { inputs = await decode_complete_process_inputs(props.krg, step.process) } catch (e) {}
+        let output: unknown | undefined
+        try { output = await decode_complete_process_output(props.krg, step.process) } catch (e) {}
         story = metanode.story ? metanode.story({ inputs, output }) : undefined
       }
       return {

--- a/spec/error.ts
+++ b/spec/error.ts
@@ -9,8 +9,8 @@ export class ResponseCodedError extends Error {
  * The method is not supported
  */
 export class UnsupportedMethodError extends ResponseCodedError {
-  constructor() {
-    super(405, 'Unsupported method')
+  constructor(message = 'Unsupported method') {
+    super(405, message)
     Object.setPrototypeOf(this, UnsupportedMethodError.prototype)
   }
 }
@@ -19,8 +19,8 @@ export class UnsupportedMethodError extends ResponseCodedError {
  * The resource is not found
  */
 export class NotFoundError extends ResponseCodedError {
-  constructor() {
-    super(404, 'Not Found')
+  constructor(message = 'Not Found') {
+    super(404, message)
     Object.setPrototypeOf(this, NotFoundError.prototype)
   }
 }
@@ -29,8 +29,8 @@ export class NotFoundError extends ResponseCodedError {
  * The resource is not found
  */
 export class UnauthorizedError extends ResponseCodedError {
-  constructor() {
-    super(401, 'Unauthorized')
+  constructor(message = 'Unauthorized') {
+    super(401, message)
     Object.setPrototypeOf(this, UnauthorizedError.prototype)
   }
 }
@@ -40,8 +40,8 @@ export class UnauthorizedError extends ResponseCodedError {
  *  fortunately, even if it occurs the job will requeue still making progress.
  */
 export class TimeoutError extends ResponseCodedError {
-  constructor() {
-    super(504, 'Timeout reached')
+  constructor(message = 'Timeout reached') {
+    super(504, message)
     Object.setPrototypeOf(this, TimeoutError.prototype)
   }
 }
@@ -50,8 +50,8 @@ export class TimeoutError extends ResponseCodedError {
  * This error occurs when the input node is not populated yet
  */
 export class UnboundError extends ResponseCodedError {
-  constructor() {
-    super(422, 'Refusing to submit unbound variable')
+  constructor(message = 'Refusing to submit unbound variable') {
+    super(422, message)
     Object.setPrototypeOf(this, UnboundError.prototype)
   }
 }

--- a/utils/next-rest-fetcher.ts
+++ b/utils/next-rest-fetcher.ts
@@ -6,12 +6,13 @@ export default async function fetcher<T>(...args: Parameters<typeof fetch>): Pro
     if (req.status >= 200 && req.status < 300) {
       return await req.json()
     } else {
-      if (req.status === 405) throw new UnsupportedMethodError()
-      else if (req.status === 404) throw new NotFoundError()
-      else if (req.status === 401) throw new UnauthorizedError()
-      else if (req.status === 504) throw new TimeoutError()
-      else if (req.status === 422) throw new UnboundError()
-      else throw new ResponseCodedError(req.status, await req.json())
+      const message = await req.text()
+      if (req.status === 405) throw new UnsupportedMethodError(message)
+      else if (req.status === 404) throw new NotFoundError(message)
+      else if (req.status === 401) throw new UnauthorizedError(message)
+      else if (req.status === 504) throw new TimeoutError(message)
+      else if (req.status === 422) throw new UnboundError(message)
+      else throw new ResponseCodedError(req.status, message)
     }
   } catch (e) {
     throw e

--- a/utils/next-rest.ts
+++ b/utils/next-rest.ts
@@ -14,13 +14,13 @@ function augmentRequestWithExtras(req: NextApiRequest) {
   return req as NextApiRequestWithExtras
 }
 
-const handler = (handler_: (req: NextApiRequestWithExtras, res: NextApiResponse) => Promise<void>) => async (req: NextApiRequest, res: NextApiResponse, { throwOnError = false }: { throwOnError?: boolean } = {}) => {
+const handler = (handler_: (req: NextApiRequestWithExtras, res: NextApiResponse) => Promise<void>) => async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     await handler_(augmentRequestWithExtras(req), res)
   } catch (e) {
     res
       .status(('error_code' in (e as ResponseCodedError)) ? (e as ResponseCodedError).error_code : 500)
-      .json((e as Error).toString())
+      .send((e as ResponseCodedError).message ?? (e as Error).toString())
   }
 }
 export default handler


### PR DESCRIPTION
![image](https://github.com/nih-cfde/playbook-partnership/assets/1341861/afec8737-bd3a-4a5e-befe-d90921a00656)

## Outstanding Blockers
- [x] I currently call `https://biocomputeobject.org/api/objects/drafts/create/` with the ORCID id_token and a blank body to check if the user has a valid BioCompute Object account. I get either 403 (no account) or 500 (has an account but I sent a malformed request). Instead of triggering 500s it'd be helpful to have another endpoint for checking this, I couldn't find another which worked.
- [x] Listing objects with `https://biocomputeobject.org/api/objects/?contents=${url}` , using ORCID id_token, gives me a permission error at the moment so the published detection won't work until the portal API is fixed
- [x] It's unclear what the best link to send users to once we get the results from the above listing, though that may become more obvious when the endpoint is working. i.e. is it `https://biocomputeobject.org/${object_id}`?

@HadleyKing Please review these blockers


Fixes #136 