### PR TITLE
Feature adds and bug fix

### DIFF
--- a/components/gly_gen/gene/sup_functions.ts
+++ b/components/gly_gen/gene/sup_functions.ts
@@ -52,14 +52,15 @@ export async function filter_glygen_proteins(gene_symbol: String): Promise<GlyGe
   const protein_result = await protein_response.json();
 
   // filter list results 
+  console.log("Gene symbol: %s", gene_symbol)
   for (const item of protein_result["results"]) {
     if (item.hasOwnProperty("gene_name")) {
       const gene_name = item["gene_name"].toUpperCase();
       const species = item["organism"];
+      console.log("----------------------------")
       console.log("-> Prop name: %s", gene_name);
       console.log("-> Species: %s", species);
-      console.log("+> Species match?: %s", gene_name )
-      if (gene_name === gene_symbol.toUpperCase() && species === "Homo sapiens") {
+      if (gene_name === gene_symbol.toUpperCase() && species === "Human") {
         console.log("==========================")
         console.log(`Human result: ${item["gene_name"]}`)
         console.log(`Type of result: ${typeof(item)}`)

--- a/components/gly_gen/protein/data_models.ts
+++ b/components/gly_gen/protein/data_models.ts
@@ -1,5 +1,5 @@
-import React from 'react'
-import { z } from 'zod';
+import React from "react";
+import { z } from "zod";
 
 // --- Supplementary Data Models for the Main Data Models --- //
 
@@ -8,15 +8,15 @@ const GlycosylationEntry = z.object({
   site_lbl: z.string(),
   site_category: z.string(),
   type: z.string(),
-  glytoucan_ac: z.string()
+  glytoucan_ac: z.string(),
 });
 
-export const GlycosylationArray = z.array(GlycosylationEntry)
+export const GlycosylationArray = z.array(GlycosylationEntry);
 export const GlycosylationData = z.object({
   glycosylation: z.boolean(),
   glycosylation_data: GlycosylationArray.optional(),
-  protein_accession: z.string()
-})
+  protein_accession: z.string(),
+});
 
 // Phosphorylation entry data models
 const PhosphorylationEntry = z.object({
@@ -25,96 +25,154 @@ const PhosphorylationEntry = z.object({
   kinase_uniprot_canonical_ac: z.string().optional(),
   kinase_gene_name: z.string().optional(),
   residue: z.string(),
-  comment: z.string().optional()
-})
+  comment: z.string().optional(),
+});
 
-export const PhosphorylationArray = z.array(PhosphorylationEntry)
+export const PhosphorylationArray = z.array(PhosphorylationEntry);
 export const PhosphorylationData = z.object({
   phosphorylation: z.boolean(),
-  phosphorylation_data: PhosphorylationArray.optional()
-})
+  phosphorylation_data: PhosphorylationArray.optional(),
+});
+
+// Section stats entry data models
+const SectionStatsEntry = z.object({
+  table_id: z.string(),
+  table_stats: z.array(
+    z.object({
+      field: z.string(),
+      count: z.number(),
+    }),
+  ),
+  sort_fields: z.array(z.string()).optional(),
+});
+export const SectionStatsArray = z.array(SectionStatsEntry);
+
+// SNV entry data models
+const SNVEntry = z.object({
+  evidence: z.array(
+    z.object({
+      id: z.string(),
+      database: z.string(),
+      url: z.string(),
+    }),
+  ),
+  glycoeffect: z.array(z.string()).optional(),
+  start_pos: z.number(),
+  end_pos: z.number(),
+  sequence_org: z.string(),
+  sequence_mut: z.string(),
+  comment: z.string(),
+  chr_id: z.string(),
+  chr_pos: z.string(),
+  ref_nt: z.string(),
+  alt_nt: z.string(),
+  site_lbl: z.string(),
+  disease: z
+    .array(
+      z.object({
+        disease_id: z.string(),
+        recommended_name: z.object({
+          id: z.string(),
+          resource: z.string(),
+          url: z.string(),
+          name: z.string(),
+          description: z.string().optional(),
+        }),
+      }),
+    )
+    .optional(),
+  keywords: z.array(z.string()),
+});
+const SNVArray = z.array(SNVEntry);
 
 // --- Main Protein Data Models --- //
 
 // Formatted GlyGen protein response data model
-export const GlyGenProteinResponse = z.object({
-  gene: z.object({
-    name: z.string(),
-    locus: z.object({
-      chromosome: z.string(),
-      start_pos: z.number(),
-      end_pos: z.number(),
-      strand: z.string()
-    })
-  }),
-  uniprot: z.object({
-    uniprot_id: z.string(),
-    uniprot_canonical_ac: z.string(),
-    length: z.number()
-  }),
-  protein_names: z.object({
-    name: z.string()
-  }),
-  species: z.object({
-    name: z.string(),
-    common_name: z.string(),
-    taxid: z.string(),
-  }),
-  glycoprotein: GlycosylationData,
-  phosphorylation: PhosphorylationData
-}).strip();
-
-// Formatted GlyGen protein set response data model 
-export const GlyGenProteinSetResponse = z.array(
-  z.object({
+export const GlyGenProteinResponse = z
+  .object({
+    snv: SNVArray,
     gene: z.object({
-      name: z.string()
+      name: z.string(),
+      locus: z.object({
+        chromosome: z.string(),
+        start_pos: z.number(),
+        end_pos: z.number(),
+        strand: z.string(),
+      }),
     }),
     uniprot: z.object({
-      uniprot_canonical_ac: z.string()
+      uniprot_id: z.string(),
+      uniprot_canonical_ac: z.string(),
+      length: z.number(),
     }),
     protein_names: z.object({
-      name: z.string()
+      name: z.string(),
     }),
     species: z.object({
       name: z.string(),
-      taxid: z.string()
+      common_name: z.string(),
+      taxid: z.string(),
+    }),
+    glycoprotein: GlycosylationData,
+    phosphorylation: PhosphorylationData,
+    section_stats: SectionStatsArray,
+  })
+  .strip();
+export const GlyGenProteinResponseArray = z.array(GlyGenProteinResponse)
+
+// Formatted GlyGen protein set response data model
+export const GlyGenProteinSetResponse = z.array(
+  z.object({
+    gene: z.object({
+      name: z.string(),
+    }),
+    uniprot: z.object({
+      uniprot_canonical_ac: z.string(),
+    }),
+    protein_names: z.object({
+      name: z.string(),
+    }),
+    species: z.object({
+      name: z.string(),
+      taxid: z.string(),
     }),
     bools: z.object({
       total_n_glycosites: z.number(),
       total_o_glycosites: z.number(),
       reported_phosphosites: z.number(),
-      reported_snv: z.number()
-    })
-  })
-)
+      reported_snv: z.number(),
+    }),
+  }),
+);
 
-// --- Supplementary Data Models for Handling API Responses -- //
+// --- Supplementary Data Models for Handling API Responses in the Supplementary Functions -- //
 
 // Name model for GlyGen Protein detail endpoint
 export const ProteinNameAPIResponse = z.object({
-    name: z.string(),
-    resource: z.string().optional(),
-    type: z.string(),
-    id: z.string().optional()
-})
+  name: z.string(),
+  resource: z.string().optional(),
+  type: z.string(),
+  id: z.string().optional(),
+});
 
 // Glycosylation model for GlyGen Protein detail endpoint
-export const GlycosylationAPIResponse = z.object({
-  site_lbl: z.string().optional(),
-  site_category: z.string().optional(),
-  type: z.string().optional(),
-  glytoucan_ac: z.string().optional()
-}).partial();
+export const GlycosylationAPIResponse = z
+  .object({
+    site_lbl: z.string().optional(),
+    site_category: z.string().optional(),
+    type: z.string().optional(),
+    glytoucan_ac: z.string().optional(),
+  })
+  .partial();
 
 // Phosphorylation model for GlyGen Protein detail endpoint
-export const PhosphorylationAPIResponse = z.object({
-  start_pos: z.number().optional(),
-  end_pos: z.number().optional(),
-  kinase_uniprot_canonical_ac: z.string().optional(),
-  kinase_gene_name: z.string().optional(),
-  residue: z.string().optional(),
-  comment: z.string().optional()
-}).partial();
-
-
+export const PhosphorylationAPIResponse = z
+  .object({
+    start_pos: z.number().optional(),
+    end_pos: z.number().optional(),
+    kinase_uniprot_canonical_ac: z.string().optional(),
+    kinase_gene_name: z.string().optional(),
+    residue: z.string().optional(),
+    comment: z.string().optional(),
+  })
+  .partial();

--- a/components/gly_gen/protein/index.tsx
+++ b/components/gly_gen/protein/index.tsx
@@ -284,6 +284,14 @@ export const SNVViewResponseNode = MetaNode("SNVViewResponseNode")
   })
   .codec(GlyGenProteinResponseArray)
   .view((data) => {
+    const get_keywords = (keywords: Array<String>) => {
+      const valid_keywords = keywords.filter(
+        (kw) =>
+          kw.toLowerCase() === "somatic" || kw.toLowerCase() === "germline",
+      );
+      if (valid_keywords.length === 0) return "NA";
+      return valid_keywords.join("; ");
+    };
     return (
       <div className="prose max-w-none">
         <table>
@@ -297,6 +305,7 @@ export const SNVViewResponseNode = MetaNode("SNVViewResponseNode")
               <th>End Pos</th>
               <th>Sequence</th>
               <th>Disease</th>
+              <th>Keywords</th>
             </tr>
           </thead>
           <tbody>
@@ -339,6 +348,7 @@ export const SNVViewResponseNode = MetaNode("SNVViewResponseNode")
                         ))
                       : "NA"}
                   </td>
+                  <td>{get_keywords(snv.keywords)}</td>
                 </tr>
               )),
             )}

--- a/components/gly_gen/protein/index.tsx
+++ b/components/gly_gen/protein/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/service/mygeneinfo";
 import { z } from "zod";
 import { glygen_icon } from "@/icons";
-import { ProteinTerm } from "@/components/core/term";
+import { ProteinTerm, GeneTerm } from "@/components/core/term";
 import { ProteinSet } from "@/components/core/set";
 import {
   GlyGenProteinResponse,
@@ -481,5 +481,21 @@ export const SNVInformation = MetaNode("SNVInformation")
     console.log(results);
     return results;
   })
-  .story((props) => "TODO")
+  .story((props) => "The SNV data is parsed from the GlyGen Protein data and prepared for presentation in the data view metanode.")
+  .build();
+
+// Links the Protein metanode chains to the Gene process metanodes
+export const ProteinLink = MetaNode("ProteinLinkMetanode")
+  .meta({
+    label: "Get Additional Gene Data",
+    description: "Protein link",
+    icon: [glygen_icon],
+  })
+  .inputs({ glyGenProteinResponse: GlyGenProteinResponseNode })
+  .output(GeneTerm)
+  .resolve(async (props) => {
+    const geneName = props.inputs.glyGenProteinResponse.gene.name;
+    return geneName;
+  })
+  .story((props) => "The gene name was extracted from the protein response data in order to further explore the gene data.")
   .build();


### PR DESCRIPTION
Feature adds: 
- Adds an SNV process/data metanode workflow from the Protein Set data metanode for viewing protein SNV information. 
- Adds a process metanode to link the protein workflows to the gene workflow by grabbing the corresponding gene name for the protein and returning a `GeneTerm`.

Bug fix: 
- Fixes breaking change in the GlyGen APIs. 
  - GlyGen APIs used to return `"Homo Sapiens"` for the `Species` key but now returns `"Human"`, updated conditional for this change. 